### PR TITLE
58,66

### DIFF
--- a/58_LengthOfLastWord.rb
+++ b/58_LengthOfLastWord.rb
@@ -1,0 +1,13 @@
+# いくつかの単語がいくつかのスペースで区切られている文字列sが与えられたとき、その文字列の最後の単語の長さを返す。
+
+# 単語とは、スペース以外の文字のみで構成される最大の部分文字列です。
+
+ # @param {String} s
+# @return {Integer}
+def length_of_last_word(s)
+  a = s.split
+  a[-1].length
+end
+
+s = "Hello World"
+puts length_of_last_word(s)

--- a/66_PlusOne.rb
+++ b/66_PlusOne.rb
@@ -1,0 +1,24 @@
+# 大きな整数が整数配列digitsとして与えられます。桁は左から右に向かって最上位から最下位の順に並んでいます。大きな整数には先頭の0は含まれていません。
+
+# 大きい方の整数を1つ増やし、その結果であるdigitsの配列を返します。
+
+# @param {Integer[]} digits
+# @return {Integer[]}
+def plus_one(digits)
+  (digits.length-1).downto(0) do |i|
+    if digits[i] != 9
+      digits[i] += 1 
+      return digits
+    else
+      digits[i] = 0
+    end
+  end
+  if digits[0] == 0
+    digits[0] = 1
+    digits.push(0)
+  end
+  digits
+end
+
+digits = [9,9]
+puts plus_one(digits)


### PR DESCRIPTION
58. Length of Last Word
3分で解けた。
空白をsplitで分割して配列に入れる。配列を-1で最後の要素を指定し、lengthで数を数えた。


66. Plus One
downtoメソッドを使用した。一の位から判定したかったのでdowntoで回し、9のとき0にして次に回す。9でないとき+1して次に回さずreturnする。これでいかなる場合も+1でreturnすることができたが問題は9のときや99のときなどである。
このとき0や00が返ってくるため誤りになってしまう。原始的ではあるがdigits[0]が0のときdigits[0]=1して0をpushした。
push(1)で一番左に入れるコマンドはあるのだろうか？

面白い解答を見つけた。joinですべてを結合してto_iで整数型に変換し+1する。その後to_sにしてsplitで分割しto_iに戻すというもの。なるほどと感じた。